### PR TITLE
Fix defaults being double-json encoded

### DIFF
--- a/faust_avro/parsers/avro.py
+++ b/faust_avro/parsers/avro.py
@@ -1,10 +1,8 @@
 import collections.abc
-import json
 from typing import Any, Dict, Iterable, Optional
 
 from faust_avro.exceptions import UnknownTypeError
 from faust_avro.schema import (
-    PRIMITIVES,
     AvroArray,
     AvroEnum,
     AvroField,
@@ -45,10 +43,7 @@ def parse_logical_type(registry: Any, **kwargs: Any) -> Schema:
 
 def parse_record_field(registry: Any, *, type, **kwargs: Any) -> AvroField:
     """Helper function to parse the type of a record field."""
-    type = parse(registry, type)
-    if "default" in kwargs and type not in PRIMITIVES[-2:]:
-        kwargs["default"] = json.loads(kwargs["default"])
-    return AvroField(type=type, **kwargs)
+    return AvroField(type=parse(registry, type), **kwargs)
 
 
 def parse_complex(

--- a/faust_avro/parsers/faust.py
+++ b/faust_avro/parsers/faust.py
@@ -73,7 +73,7 @@ def parse_field(registry: Any, model: FieldDescriptor, namespace: str) -> Schema
     if model.required:
         return AvroField(model.field, schema)
     else:
-        return AvroField(model.field, schema, None, model.default)
+        return AvroField(model.field, schema, None, default=model.default)
 
 
 def parse_enum(registry: Any, model: EnumMeta, namespace: str) -> Schema:

--- a/faust_avro/schema.py
+++ b/faust_avro/schema.py
@@ -5,12 +5,11 @@ These get constructed from either a json-parsed avro schema, or from a python
 dataclass.
 """
 
-import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
 from importlib import import_module
-from typing import Any, Iterable, List, Optional, Set, Union
+from typing import Any, Iterable, List, Optional, Set
 
 __all__ = [
     # Types
@@ -159,20 +158,13 @@ class AvroField(Schema):
     name: str
     type: Any
     doc: Optional[str] = None
-    default: Optional[Any] = MISSING  # Can't use None, because that's a valid default
-    order: Optional[
-        Ordering
-    ] = None  # Must be None so we don't add this to the schema if unspecified
     aliases: Iterable[str] = field(default_factory=list)
 
-    def _default(self) -> Union[str, object]:
-        if self.default == MISSING:
-            return MISSING
-        elif self.type in PRIMITIVES[-2:]:
-            # Don't try to json-dump str or bytes, they are fine as-is.
-            return self.default
-        else:
-            return json.dumps(self.default)
+    # Can't use None, because that's a valid default
+    default: Optional[Any] = MISSING
+
+    # Must be None so we don't add this to the schema if unspecified
+    order: Optional[Ordering] = None
 
     def _to_avro(self, visited: VisitedT) -> AvroSchemaT:
         return self._add_fields(
@@ -181,7 +173,7 @@ class AvroField(Schema):
             "order",
             "aliases",
             type=self.type._to_avro(visited),
-            default=self._default(),
+            default=self.default,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "faust_avro"
-version = "0.1.3"
+version = "0.1.4"
 description = "Avro codec and schema registry support for Faust"
 authors = ["Mastery Systems LLC <oss@mastery.net>"]
 readme = "README.md"

--- a/tests/parsers/test_avro.py
+++ b/tests/parsers/test_avro.py
@@ -44,7 +44,7 @@ def fixed(name, size=16, **kwargs):
         "bytes",
         "string",
         # Complex types
-        record("Record", fields=[field("field", "boolean", default="true")]),
+        record("Record", fields=[field("field", "boolean", default=True)]),
         enum("enumeration", "red", "green", "blue"),
         array("string"),
         mapping("boolean"),

--- a/tests/parsers/test_faust.py
+++ b/tests/parsers/test_faust.py
@@ -56,7 +56,7 @@ def test_faust(registry):
         timestamp: datetime
         uuid: UUID
         # Pythonic types
-        optional: Optional[str]
+        optional: Optional[str]  # Faust auto-defaults this to None.
         default: str = "a default"
         # Nested
         nested: Optional[Nested] = None


### PR DESCRIPTION
This is likely damage from a previous implementation that I didn't get cleaned up properly.