### PR TITLE
Add a command to dump the schema of a record

### DIFF
--- a/faust_avro/app.py
+++ b/faust_avro/app.py
@@ -1,5 +1,7 @@
+import click
 import faust
 
+from faust_avro.record import Record
 from faust_avro.serializers import AvroSchemaRegistry
 
 
@@ -23,6 +25,15 @@ class App(faust.App):
         async def register(_):
             """Register faust_avro.Record schemas with the schema registry."""
             await schema.register()
+
+        @self.command(faust.cli.argument('model'))
+        async def schema(app, model):
+            """Dump the schema of a faust_avro.Record model."""
+            record = app.import_relative_to_app(model)
+            if isinstance(record, type) and issubclass(record, Record):
+                app.say(await registry.to_avro(record))
+            else:
+                raise click.Abort(f"{model} is not an avro-based Record.")
 
     def topic(self, *args, **kwargs):
         topic = super().topic(*args, **kwargs)

--- a/faust_avro/serializers.py
+++ b/faust_avro/serializers.py
@@ -115,7 +115,7 @@ class AvroSchemaRegistry(faust.Schema):
             # before that agent has finished running, meaning that we are in an unready state.
             if codec.schema_id is None:
                 # This is a hack to get around the dropped async context
-                run_in_thread(codec.register(self.registry))
+                run_in_thread(codec.sync(self.registry))
             if codec.schema_id == schema_id:
                 return codec
         else:
@@ -153,7 +153,7 @@ class AvroSchemaRegistry(faust.Schema):
         codec = self.codecs[type(data)]
         if codec.schema_id is None:
             # This is a hack to get around the dropped async context
-            run_in_thread(codec.register(self.registry))
+            run_in_thread(codec.sync(self.registry))
         header = HEADER.pack(MAGIC_BYTE, codec.schema_id)
         return header + codec.dumps(data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "faust_avro"
-version = "0.1.4"
+version = "0.2.0"
 description = "Avro codec and schema registry support for Faust"
 authors = ["Mastery Systems LLC <oss@mastery.net>"]
 readme = "README.md"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,4 @@
+import subprocess
 import tempfile
 
 import pytest
@@ -30,3 +31,13 @@ async def test_app():
 
         # faust_avro apps must have AvroSchemaRegistry as the schema of a topic
         assert_that(people.schema).is_type_of(AvroSchemaRegistry)
+
+
+def test_schema():
+    # This test is really slow -- does it add enough value to keep it?
+    # No negative test because I don't want it slower...
+    cmd = """python -m faust -A examples.log_message schema examples.log_message.LogMessage"""
+    result = subprocess.run(cmd.split(), check=True, stdout=subprocess.PIPE)
+    assert_that(result.stdout).is_equal_to(
+        b'{"type": "record", "name": "examples.log_message.LogMessage", "aliases": ["LogMessage"], "fields": [{"type": "string", "name": "fmt"}, {"type": {"type": "map", "values": "string"}, "name": "data"}]}\n'
+    )


### PR DESCRIPTION
Adds `faust -A <path.to.faust.App> schema <module.path.and.Model>` command to faust in order to dump the avro schema. I added a test too, although the test is very slow and so I'm a bit tempted to ignore testing the minimal command method code itself and push down testing to against the schema registry method it hits.