### PR TITLE
Fetch unknown schemas from the registry

### DIFF
--- a/faust_avro/__init__.py
+++ b/faust_avro/__init__.py
@@ -6,11 +6,9 @@ from faust_avro.exceptions import (
     UnknownTypeError,
 )
 from faust_avro.record import Record
-from faust_avro.serializers import AvroSchemaRegistry
 
 __all__ = [
     "App",
-    "AvroSchemaRegistry",
     "CodecException",
     "Record",
     "SchemaException",

--- a/faust_avro/app.py
+++ b/faust_avro/app.py
@@ -1,46 +1,42 @@
+import asyncio
+
 import click
 import faust
 
+from faust_avro.asyncio import ConfluentSchemaRegistryClient
 from faust_avro.record import Record
-from faust_avro.serializers import AvroSchemaRegistry
+from faust_avro.serializers import Schema
+from faust_avro.topic import Topic
 
 
 class App(faust.App):
+    avro_schema_registry: ConfluentSchemaRegistryClient
+
     def __init__(self, *args, registry_url="http://localhost:8081", **kwargs):
         """Create a new Avro enabled Faust app.
 
         :param registry_url: The base URL to the schema registry.
         """
-        registry = AvroSchemaRegistry(registry_url=registry_url)
-        schema = kwargs.setdefault("Schema", registry)
+        kwargs.setdefault("Schema", Schema)
+        kwargs.setdefault("Topic", Topic)
         super().__init__(*args, **kwargs)
-
-        @self.service
-        class AvroSchemaRegistryService(faust.Service):
-            async def on_start(_):
-                """Fetch faust_avro.Record schema ids from the schema registry."""
-                await registry.sync()
+        self.avro_schema_registry = ConfluentSchemaRegistryClient(registry_url)
 
         @self.command()
         async def register(_):
             """Register faust_avro.Record schemas with the schema registry."""
-            await registry.register()
+            channels = [agent.channel for agent in _.app.agents.values()]
+            topics = [chan for chan in channels if isinstance(chan, Topic)]
+            tasks = [topic.compatible(_.app) for topic in topics]
+            if all(await asyncio.gather(*tasks)):
+                tasks = [topic.register(_.app) for topic in topics]
+                await asyncio.gather(*tasks)
 
-        @self.command(faust.cli.argument('model'))
-        async def schema(app, model):
+        @self.command(faust.cli.argument("model"))
+        async def schema(_, model):
             """Dump the schema of a faust_avro.Record model."""
-            record = app.import_relative_to_app(model)
+            record = _.import_relative_to_app(model)
             if isinstance(record, type) and issubclass(record, Record):
-                app.say(await registry.to_avro(record))
+                _.say(record.to_avro(_.app.avro_schema_registry.registry))
             else:
                 raise click.Abort(f"{model} is not an avro-based Record.")
-
-    def topic(self, *args, **kwargs):
-        topic = super().topic(*args, **kwargs)
-
-        for which in ["key", "value"]:
-            record = kwargs.get(f"{which}_type")
-            if record:
-                topic.schema.define(topic.topics, which, record)
-
-        return topic

--- a/faust_avro/asyncio.py
+++ b/faust_avro/asyncio.py
@@ -5,6 +5,8 @@ import typing
 
 import aiohttp
 
+from faust_avro.registry import Registry
+
 JSON = typing.AsyncGenerator[typing.Dict[str, typing.Any], None]
 SchemaID = int
 Subject = str
@@ -14,13 +16,13 @@ Schema = str
 CONTENT_TYPE = {"Content-Type": "application/vnd.schemaregistry.v1+json"}
 
 
-def _run_in_thread(coro):
+def _run_in_thread(coro: typing.Awaitable) -> None:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     loop.run_until_complete(coro)
 
 
-def run_in_thread(coro):
+def run_in_thread(coro: typing.Awaitable) -> None:
     """Runs a coroutine in a separate loop/thread.
 
     Use this when you're running in a loop, but have had the `async def`
@@ -28,7 +30,7 @@ def run_in_thread(coro):
 
     Mostly, just don't use this.
     """
-    thread = threading.Thread(target=_run_in_thread, args=(coro, ))
+    thread = threading.Thread(target=_run_in_thread, args=(coro,))
     thread.start()
     thread.join()
 
@@ -56,6 +58,7 @@ class ConfluentSchemaRegistryClient:
         :param url: The base URL to the schema registry.
         """
         self.url: str = url
+        self.registry: Registry = Registry()
 
     @contextlib.asynccontextmanager
     async def get(self, path: str) -> JSON:

--- a/faust_avro/context.py
+++ b/faust_avro/context.py
@@ -1,0 +1,24 @@
+"""
+Conext Vars are used here to avoid having to overload many methods of the send/receive
+message traces in order to pass the topic/app/subject down from higher levels (eg, topic.send, schema.loads_*)
+to lower levels (eg, Codec.dumps/loads) in order to be able to perform schema lookups
+with the schema registry without having to pass topic/app/subject args through the
+full call stack between them.
+"""
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+from faust.types import TopicT
+from faust.types.app import AppT
+
+app: ContextVar[AppT] = ContextVar("app")
+subject: ContextVar[str] = ContextVar("subject")
+topic: ContextVar[TopicT] = ContextVar("topic")
+
+
+@contextmanager
+def context(var: ContextVar, value: Any):
+    token = var.set(value)
+    yield
+    var.reset(token)

--- a/faust_avro/record.py
+++ b/faust_avro/record.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Iterable, Optional
+from typing import Any, ClassVar, Dict, Iterable, Optional
 
 import faust
 
@@ -18,7 +18,7 @@ class Record(faust.Record, abstract=True):
         cls._avro_aliases = avro_aliases or [cls.__name__]
 
     @classmethod
-    def to_avro(cls, registry):
+    def to_avro(cls, registry) -> Dict[str, Any]:
         from faust_avro.parsers.faust import parse
 
         avro_schema = parse(registry, cls)

--- a/faust_avro/schema.py
+++ b/faust_avro/schema.py
@@ -125,7 +125,7 @@ class NamedSchema(Schema):
 
     python_type: Optional[type] = field(default=None, compare=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         try:
             self.python_type = self._import_class(self.name)
         except ImportError:
@@ -206,7 +206,7 @@ class AvroEnum(NamedSchema):
     symbols: Iterable[str] = field(default_factory=list)
     default: Optional[str] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__post_init__()
         if self.python_type is None:
             self.python_type = Enum(self.name, " ".join(self.symbols))

--- a/faust_avro/topic.py
+++ b/faust_avro/topic.py
@@ -1,0 +1,45 @@
+from typing import Any, Tuple
+
+import faust
+from faust.types import AppT, CodecArg, SchemaT
+from faust.types.core import K, OpenHeadersArg, V
+
+from faust_avro.context import context, topic
+from faust_avro.serializers import Schema
+
+
+class Topic(faust.Topic):
+    """A modified faust.Topic that injects itself into the schema.dumps call."""
+
+    schema: Schema
+
+    def prepare_key(
+        self,
+        key: K,
+        key_serializer: CodecArg,
+        schema: SchemaT = None,
+        headers: OpenHeadersArg = None,
+    ) -> Tuple[Any, OpenHeadersArg]:
+        """Serialize key to format suitable for transport."""
+        with context(topic, self):
+            return super().prepare_key(key, key_serializer, schema, headers)
+
+    def prepare_value(
+        self,
+        value: V,
+        value_serializer: CodecArg,
+        schema: SchemaT = None,
+        headers: OpenHeadersArg = None,
+    ) -> Tuple[Any, OpenHeadersArg]:
+        """Serialize value to format suitable for transport."""
+        with context(topic, self):
+            return super().prepare_value(value, value_serializer, schema, headers)
+
+    async def compatible(self, app: AppT) -> bool:
+        return all(await self.schema.compatible(app, self))
+
+    async def register(self, app: AppT) -> None:
+        await self.schema.register(app, self)
+
+    async def sync(self, app: AppT) -> None:
+        await self.schema.sync(app, self)

--- a/poetry.lock
+++ b/poetry.lock
@@ -135,7 +135,7 @@ typed-ast = ">=1.4.0"
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-category = "main"
+category = "dev"
 description = "A decorator for caching properties in classes."
 name = "cached-property"
 optional = false
@@ -1062,7 +1062,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "348c81098f9ae22e22a8914dd0cdb947e578c91902014acf12c4a8b0797a047d"
+content-hash = "3602260e2f666e0d68ca683c5008102aba71eb95a3fc3cbc805536340cf91ac4"
 python-versions = "^3.7"
 
 [metadata.files]

--- a/poetry.lock
+++ b/poetry.lock
@@ -148,7 +148,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.9.11"
+version = "2019.11.28"
 
 [[package]]
 category = "dev"
@@ -257,7 +257,7 @@ description = "Faker is a Python package that generates fake data for you."
 name = "faker"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.0.4"
+version = "3.0.0"
 
 [package.dependencies]
 python-dateutil = ">=2.4"
@@ -338,15 +338,15 @@ description = "A fancy and practical functional tools"
 name = "funcy"
 optional = false
 python-versions = "*"
-version = "1.13"
+version = "1.14"
 
 [[package]]
 category = "dev"
 description = "File identification library for Python"
 name = "identify"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "1.4.8"
 
 [package.extras]
 license = ["editdistance"]
@@ -373,8 +373,8 @@ description = "Read metadata from Python packages"
 marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
-python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "0.23"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.2.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -470,8 +470,8 @@ category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
-python-versions = ">=3.4"
-version = "7.2.0"
+python-versions = ">=3.5"
+version = "8.0.0"
 
 [[package]]
 category = "main"
@@ -479,7 +479,7 @@ description = "multidict implementation"
 name = "multidict"
 optional = false
 python-versions = ">=3.5"
-version = "4.6.0"
+version = "4.6.1"
 
 [[package]]
 category = "dev"
@@ -488,7 +488,7 @@ marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_versi
 name = "mypy"
 optional = false
 python-versions = ">=3.5"
-version = "0.740"
+version = "0.750"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.0,<0.5.0"
@@ -551,7 +551,7 @@ description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.0"
+version = "0.13.1"
 
 [package.dependencies]
 [package.dependencies.importlib-metadata]
@@ -613,7 +613,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.4.2"
+version = "2.5.2"
 
 [[package]]
 category = "dev"
@@ -764,7 +764,7 @@ description = "YAML parser and emitter for Python"
 name = "pyyaml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "5.1.2"
+version = "5.2"
 
 [[package]]
 category = "dev"
@@ -839,7 +839,7 @@ description = "Python documentation generator"
 name = "sphinx"
 optional = false
 python-versions = ">=3.5"
-version = "2.2.1"
+version = "2.2.2"
 
 [package.dependencies]
 Jinja2 = ">=2.3"
@@ -862,7 +862,7 @@ sphinxcontrib-serializinghtml = "*"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-test = ["pytest", "pytest-cov", "html5lib", "flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.740)", "docutils-stubs"]
+test = ["pytest", "pytest-cov", "html5lib", "flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.750)", "docutils-stubs"]
 
 [[package]]
 category = "dev"
@@ -1019,7 +1019,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "16.7.7"
+version = "16.7.8"
 
 [package.extras]
 docs = ["sphinx (>=1.8.0,<2)", "towncrier (>=18.5.0)", "sphinx-rtd-theme (>=0.4.2,<1)"]
@@ -1038,8 +1038,8 @@ category = "main"
 description = "Yet another URL library"
 name = "yarl"
 optional = false
-python-versions = ">=3.5.3"
-version = "1.3.0"
+python-versions = ">=3.5"
+version = "1.4.2"
 
 [package.dependencies]
 idna = ">=2.0"
@@ -1128,8 +1128,8 @@ cached-property = [
     {file = "cached_property-1.5.1-py2.py3-none-any.whl", hash = "sha256:3a026f1a54135677e7da5ce819b0c690f156f37976f3e30c5430740725203d7f"},
 ]
 certifi = [
-    {file = "certifi-2019.9.11-py2.py3-none-any.whl", hash = "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"},
-    {file = "certifi-2019.9.11.tar.gz", hash = "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50"},
+    {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
+    {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
 ]
 cfgv = [
     {file = "cfgv-2.0.1-py2.py3-none-any.whl", hash = "sha256:fbd93c9ab0a523bf7daec408f3be2ed99a980e20b2d19b50fc184ca6b820d289"},
@@ -1206,8 +1206,8 @@ factory-boy = [
     {file = "factory_boy-2.12.0.tar.gz", hash = "sha256:faf48d608a1735f0d0a3c9cbf536d64f9132b547dae7ba452c4d99a79e84a370"},
 ]
 faker = [
-    {file = "Faker-2.0.4-py2.py3-none-any.whl", hash = "sha256:48c03580720e0b46538d528b1296e4e5b24a809dcaf33a7dddec719489a9edb8"},
-    {file = "Faker-2.0.4.tar.gz", hash = "sha256:6327c665c0d8721280b3036d9c9e851c60092bc1f30c8394cc433f8723e2bda5"},
+    {file = "Faker-3.0.0-py2.py3-none-any.whl", hash = "sha256:202ad3b2ec16ae7c51c02904fb838831f8d2899e61bf18db1e91a5a582feab11"},
+    {file = "Faker-3.0.0.tar.gz", hash = "sha256:92c84a10bec81217d9cb554ee12b3838c8986ce0b5d45f72f769da22e4bb5432"},
 ]
 fastavro = [
     {file = "fastavro-0.22.7-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:1f3b7f23005c423fb9c6e2a933ada01bca3962fd266458055c9653b1c9c3d16c"},
@@ -1243,12 +1243,11 @@ flake8 = [
     {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
 ]
 funcy = [
-    {file = "funcy-1.13-py2.py3-none-any.whl", hash = "sha256:141950038e72bdc2d56fa82468586a1d1291b9cc9346daaaa322dffed1d1da6e"},
-    {file = "funcy-1.13.tar.gz", hash = "sha256:918f333f675d9841ec7d77b9f0d5a272ed290393a33c8ef20e605847de89b1c3"},
+    {file = "funcy-1.14.tar.gz", hash = "sha256:75ee84c3b446f92e68a857c2267b15a1b49c631c9d5a87a5f063cd2d6761a5c4"},
 ]
 identify = [
-    {file = "identify-1.4.7-py2.py3-none-any.whl", hash = "sha256:4f1fe9a59df4e80fcb0213086fcf502bc1765a01ea4fe8be48da3b65afd2a017"},
-    {file = "identify-1.4.7.tar.gz", hash = "sha256:d8919589bd2a5f99c66302fec0ef9027b12ae150b0b0213999ad3f695fc7296e"},
+    {file = "identify-1.4.8-py2.py3-none-any.whl", hash = "sha256:9e7521e9abeaede4d2d1092a106e418c65ddf6b3182b43930bcb3c8cfb974488"},
+    {file = "identify-1.4.8.tar.gz", hash = "sha256:7782115794ec28b011702815d9f5e532244560cd2bf0789c4f09381d43befd90"},
 ]
 idna = [
     {file = "idna-2.8-py2.py3-none-any.whl", hash = "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"},
@@ -1259,8 +1258,8 @@ imagesize = [
     {file = "imagesize-1.1.0.tar.gz", hash = "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-0.23-py2.py3-none-any.whl", hash = "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"},
-    {file = "importlib_metadata-0.23.tar.gz", hash = "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26"},
+    {file = "importlib_metadata-1.2.0-py2.py3-none-any.whl", hash = "sha256:3a8b2dfd0a2c6a3636e7c016a7e54ae04b997d30e69d5eacdca7a6c2221a1402"},
+    {file = "importlib_metadata-1.2.0.tar.gz", hash = "sha256:41e688146d000891f32b1669e8573c57e39e5060e7f5f647aa617cd9a9568278"},
 ]
 inflection = [
     {file = "inflection-0.3.1.tar.gz", hash = "sha256:18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca"},
@@ -1316,43 +1315,43 @@ mode = [
     {file = "mode-4.1.3.tar.gz", hash = "sha256:f9435c69f7078cb3160cd4ef23b98cda38a9f7feb60ab17ab125228803bfc02a"},
 ]
 more-itertools = [
-    {file = "more-itertools-7.2.0.tar.gz", hash = "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832"},
-    {file = "more_itertools-7.2.0-py3-none-any.whl", hash = "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"},
+    {file = "more-itertools-8.0.0.tar.gz", hash = "sha256:53ff73f186307d9c8ef17a9600309154a6ae27f25579e80af4db8f047ba14bc2"},
+    {file = "more_itertools-8.0.0-py3-none-any.whl", hash = "sha256:a0ea684c39bc4315ba7aae406596ef191fd84f873d2d2751f84d64e81a7a2d45"},
 ]
 multidict = [
-    {file = "multidict-4.6.0-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:ee2a54a197392752ca1bcd9cdb0e2a96fdefe2f0e029b2c09b72e03197c88a52"},
-    {file = "multidict-4.6.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:56b6d68a491884878f71a9e26cb97938be079676fb085f8918b5c04341d32fcc"},
-    {file = "multidict-4.6.0-cp35-cp35m-win32.whl", hash = "sha256:e74cbadef9c961152c765f64efe959c8051d9fcfb89f18bcdf1fdd6e60facfc7"},
-    {file = "multidict-4.6.0-cp35-cp35m-win_amd64.whl", hash = "sha256:f83cb1ca64da2c3793a3b18998008f451e6898fc07efd44567855378d84251ae"},
-    {file = "multidict-4.6.0-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:fb1274ca2fc7a510b85b07923c54ffd2186b8043e191b2b791f9b578a8609504"},
-    {file = "multidict-4.6.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:08f00f616e4353dcdc0d099f36a41ec97246bf21f8c47bcdc0dded2f7d19a504"},
-    {file = "multidict-4.6.0-cp36-cp36m-win32.whl", hash = "sha256:eef66d45b31a6419c6ba35a782fcb5c34ffffc92d7a551e56ff30a2000640d8d"},
-    {file = "multidict-4.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:8f36da9daa09442ce948a62920dd07db79cbfec7e3bbf59aafbf1074cf12a1e6"},
-    {file = "multidict-4.6.0-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:9190079aba47b54332bbcc45076c920622178f8df46e518bdbbfdf248c263947"},
-    {file = "multidict-4.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:79eb0e87345581ee54517aa992a7ba712992cc49365ebe8dee8941deff8f05fa"},
-    {file = "multidict-4.6.0-cp37-cp37m-win32.whl", hash = "sha256:92c2a0ca7eaac81fd666f62a9020ad076c98b49e2176c1687b00ea736c7f5470"},
-    {file = "multidict-4.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b949a2c80136aec1b5b68538924c12e13f37f26d10f0ca54ff2cce84368ff8cc"},
-    {file = "multidict-4.6.0-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:38dc36421645832935221f7e59fb6a28e4b46a8964afe4bcebaf571990cca71d"},
-    {file = "multidict-4.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a832c84e304ccb14dd49c28c04c944700fe6223c6ec3a0a7cb939c54b9c79e1d"},
-    {file = "multidict-4.6.0-cp38-cp38-win32.whl", hash = "sha256:8a8a2d751d6819c78f34e9b0585b6a4bdba48419b974ea4da1f18266f4bf58be"},
-    {file = "multidict-4.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b0949bffd86aa640d3ad7c5dfc87b472097b9de44ff7c00f790eba4e5233f44f"},
-    {file = "multidict-4.6.0.tar.gz", hash = "sha256:56fb5c003ef5d7b0d4957fe2d36fc29df16e56667ef78ee2a5bc5379c874fff0"},
+    {file = "multidict-4.6.1-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:318aadf1cfb6741c555c7dd83d94f746dc95989f4f106b25b8a83dfb547f2756"},
+    {file = "multidict-4.6.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9c890978e2b37dd0dc1bd952da9a5d9f245d4807bee33e3517e4119c48d66f8c"},
+    {file = "multidict-4.6.1-cp35-cp35m-win32.whl", hash = "sha256:efaf1b18ea6c1f577b1371c0159edbe4749558bfe983e13aa24d0a0c01e1ad7b"},
+    {file = "multidict-4.6.1-cp35-cp35m-win_amd64.whl", hash = "sha256:07f9a6bf75ad675d53956b2c6a2d4ef2fa63132f33ecc99e9c24cf93beb0d10b"},
+    {file = "multidict-4.6.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:42cdd649741a14b0602bf15985cad0dd4696a380081a3319cd1ead46fd0f0fab"},
+    {file = "multidict-4.6.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:205a011e636d885af6dd0029e41e3514a46e05bb2a43251a619a6e8348b96fc0"},
+    {file = "multidict-4.6.1-cp36-cp36m-win32.whl", hash = "sha256:cfec9d001a83dc73580143f3c77e898cf7ad78b27bb5e64dbe9652668fcafec7"},
+    {file = "multidict-4.6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8d919034420378132d074bf89df148d0193e9780c9fe7c0e495e895b8af4d8a2"},
+    {file = "multidict-4.6.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:a37433ce8cdb35fc9e6e47e1606fa1bfd6d70440879038dca7d8dd023197eaa9"},
+    {file = "multidict-4.6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1b605272c558e4c659dbaf0fb32a53bfede44121bcf77b356e6e906867b958b7"},
+    {file = "multidict-4.6.1-cp37-cp37m-win32.whl", hash = "sha256:891b7e142885e17a894d9d22b0349b92bb2da4769b4e675665d0331c08719be5"},
+    {file = "multidict-4.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:250632316295f2311e1ed43e6b26a63b0216b866b45c11441886ac1543ca96e1"},
+    {file = "multidict-4.6.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:2bc9c2579312c68a3552ee816311c8da76412e6f6a9cf33b15152e385a572d2a"},
+    {file = "multidict-4.6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0ffe4d4d28cbe9801952bfb52a8095dd9ffecebd93f84bdf973c76300de783c5"},
+    {file = "multidict-4.6.1-cp38-cp38-win32.whl", hash = "sha256:87e26d8b89127c25659e962c61a4c655ec7445d19150daea0759516884ecb8b4"},
+    {file = "multidict-4.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:c626029841ada34c030b94a00c573a0c7575fe66489cde148785b6535397d675"},
+    {file = "multidict-4.6.1.tar.gz", hash = "sha256:5159c4975931a1a78bf6602bbebaa366747fce0a56cb2111f44789d2c45e379f"},
 ]
 mypy = [
-    {file = "mypy-0.740-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:9371290aa2cad5ad133e4cdc43892778efd13293406f7340b9ffe99d5ec7c1d9"},
-    {file = "mypy-0.740-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b428f883d2b3fe1d052c630642cc6afddd07d5cd7873da948644508be3b9d4a7"},
-    {file = "mypy-0.740-cp35-cp35m-win_amd64.whl", hash = "sha256:ace6ac1d0f87d4072f05b5468a084a45b4eda970e4d26704f201e06d47ab2990"},
-    {file = "mypy-0.740-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:d7574e283f83c08501607586b3167728c58e8442947e027d2d4c7dcd6d82f453"},
-    {file = "mypy-0.740-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d5bf0e6ec8ba346a2cf35cb55bf4adfddbc6b6576fcc9e10863daa523e418dbb"},
-    {file = "mypy-0.740-cp36-cp36m-win_amd64.whl", hash = "sha256:1521c186a3d200c399bd5573c828ea2db1362af7209b2adb1bb8532cea2fb36f"},
-    {file = "mypy-0.740-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:dc889c84241a857c263a2b1cd1121507db7d5b5f5e87e77147097230f374d10b"},
-    {file = "mypy-0.740-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6ed3b9b3fdc7193ea7aca6f3c20549b377a56f28769783a8f27191903a54170f"},
-    {file = "mypy-0.740-cp37-cp37m-win_amd64.whl", hash = "sha256:31a046ab040a84a0fc38bc93694876398e62bc9f35eca8ccbf6418b7297f4c00"},
-    {file = "mypy-0.740-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:672e418425d957e276c291930a3921b4a6413204f53fe7c37cad7bc57b9a3391"},
-    {file = "mypy-0.740-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3b1a411909c84b2ae9b8283b58b48541654b918e8513c20a400bb946aa9111ae"},
-    {file = "mypy-0.740-cp38-cp38-win_amd64.whl", hash = "sha256:540c9caa57a22d0d5d3c69047cc9dd0094d49782603eb03069821b41f9e970e9"},
-    {file = "mypy-0.740-py3-none-any.whl", hash = "sha256:f4748697b349f373002656bf32fede706a0e713d67bfdcf04edf39b1f61d46eb"},
-    {file = "mypy-0.740.tar.gz", hash = "sha256:48c8bc99380575deb39f5d3400ebb6a8a1cb5cc669bbba4d3bb30f904e0a0e7d"},
+    {file = "mypy-0.750-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:de9ec8dba773b78c49e7bec9a35c9b6fc5235682ad1fc2105752ae7c22f4b931"},
+    {file = "mypy-0.750-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3294821b5840d51a3cd7a2bb63b40fc3f901f6a3cfb3c6046570749c4c7ef279"},
+    {file = "mypy-0.750-cp35-cp35m-win_amd64.whl", hash = "sha256:6992133c95a2847d309b4b0c899d7054adc60481df6f6b52bb7dee3d5fd157f7"},
+    {file = "mypy-0.750-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:41696a7d912ce16fdc7c141d87e8db5144d4be664a0c699a2b417d393994b0c2"},
+    {file = "mypy-0.750-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c87ac7233c629f305602f563db07f5221950fe34fe30af072ac838fa85395f78"},
+    {file = "mypy-0.750-cp36-cp36m-win_amd64.whl", hash = "sha256:83fa87f556e60782c0fc3df1b37b7b4a840314ba1ac27f3e1a1e10cb37c89c17"},
+    {file = "mypy-0.750-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:30e123b24931f02c5d99307406658ac8f9cd6746f0d45a3dcac2fe5fbdd60939"},
+    {file = "mypy-0.750-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:02d9bdd3398b636723ecb6c5cfe9773025a9ab7f34612c1cde5c7f2292e2d768"},
+    {file = "mypy-0.750-cp37-cp37m-win_amd64.whl", hash = "sha256:088f758a50af31cf8b42688118077292370c90c89232c783ba7979f39ea16646"},
+    {file = "mypy-0.750-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4f42675fa278f3913340bb8c3371d191319704437758d7c4a8440346c293ecb2"},
+    {file = "mypy-0.750-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f385a0accf353ca1bca4bbf473b9d83ed18d923fdb809d3a70a385da23e25b6a"},
+    {file = "mypy-0.750-cp38-cp38-win_amd64.whl", hash = "sha256:54d205ccce6ed930a8a2ccf48404896d456e8b87812e491cb907a355b1a9c640"},
+    {file = "mypy-0.750-py3-none-any.whl", hash = "sha256:28e9fbc96d13397a7ddb7fad7b14f373f91b5cff538e0772e77c270468df083c"},
+    {file = "mypy-0.750.tar.gz", hash = "sha256:6ecbd0e8e371333027abca0922b0c2c632a5b4739a0c61ffbd0733391e39144c"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -1372,8 +1371,8 @@ pathspec = [
     {file = "pathspec-0.6.0.tar.gz", hash = "sha256:e285ccc8b0785beadd4c18e5708b12bb8fcf529a1e61215b3feff1d1e559ea5c"},
 ]
 pluggy = [
-    {file = "pluggy-0.13.0-py2.py3-none-any.whl", hash = "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6"},
-    {file = "pluggy-0.13.0.tar.gz", hash = "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"},
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 pre-commit = [
     {file = "pre_commit-1.20.0-py2.py3-none-any.whl", hash = "sha256:c2e4810d2d3102d354947907514a78c5d30424d299dc0fe48f5aa049826e9b50"},
@@ -1392,8 +1391,8 @@ pyflakes = [
     {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
 ]
 pygments = [
-    {file = "Pygments-2.4.2-py2.py3-none-any.whl", hash = "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127"},
-    {file = "Pygments-2.4.2.tar.gz", hash = "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"},
+    {file = "Pygments-2.5.2-py2.py3-none-any.whl", hash = "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b"},
+    {file = "Pygments-2.5.2.tar.gz", hash = "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.5-py2.py3-none-any.whl", hash = "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f"},
@@ -1439,19 +1438,17 @@ pytz = [
     {file = "pytz-2019.3.tar.gz", hash = "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"},
 ]
 pyyaml = [
-    {file = "PyYAML-5.1.2-cp27-cp27m-win32.whl", hash = "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8"},
-    {file = "PyYAML-5.1.2-cp27-cp27m-win_amd64.whl", hash = "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"},
-    {file = "PyYAML-5.1.2-cp34-cp34m-win32.whl", hash = "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9"},
-    {file = "PyYAML-5.1.2-cp34-cp34m-win_amd64.whl", hash = "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696"},
-    {file = "PyYAML-5.1.2-cp35-cp35m-win32.whl", hash = "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41"},
-    {file = "PyYAML-5.1.2-cp35-cp35m-win_amd64.whl", hash = "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73"},
-    {file = "PyYAML-5.1.2-cp36-cp36m-win32.whl", hash = "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299"},
-    {file = "PyYAML-5.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b"},
-    {file = "PyYAML-5.1.2-cp37-cp37m-win32.whl", hash = "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae"},
-    {file = "PyYAML-5.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34"},
-    {file = "PyYAML-5.1.2-cp38-cp38m-win32.whl", hash = "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9"},
-    {file = "PyYAML-5.1.2-cp38-cp38m-win_amd64.whl", hash = "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681"},
-    {file = "PyYAML-5.1.2.tar.gz", hash = "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4"},
+    {file = "PyYAML-5.2-cp27-cp27m-win32.whl", hash = "sha256:35ace9b4147848cafac3db142795ee42deebe9d0dad885ce643928e88daebdcc"},
+    {file = "PyYAML-5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:ebc4ed52dcc93eeebeae5cf5deb2ae4347b3a81c3fa12b0b8c976544829396a4"},
+    {file = "PyYAML-5.2-cp35-cp35m-win32.whl", hash = "sha256:38a4f0d114101c58c0f3a88aeaa44d63efd588845c5a2df5290b73db8f246d15"},
+    {file = "PyYAML-5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:483eb6a33b671408c8529106df3707270bfacb2447bf8ad856a4b4f57f6e3075"},
+    {file = "PyYAML-5.2-cp36-cp36m-win32.whl", hash = "sha256:7f38e35c00e160db592091751d385cd7b3046d6d51f578b29943225178257b31"},
+    {file = "PyYAML-5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:0e7f69397d53155e55d10ff68fdfb2cf630a35e6daf65cf0bdeaf04f127c09dc"},
+    {file = "PyYAML-5.2-cp37-cp37m-win32.whl", hash = "sha256:e4c015484ff0ff197564917b4b4246ca03f411b9bd7f16e02a2f586eb48b6d04"},
+    {file = "PyYAML-5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:4b6be5edb9f6bb73680f5bf4ee08ff25416d1400fbd4535fe0069b2994da07cd"},
+    {file = "PyYAML-5.2-cp38-cp38-win32.whl", hash = "sha256:8100c896ecb361794d8bfdb9c11fce618c7cf83d624d73d5ab38aef3bc82d43f"},
+    {file = "PyYAML-5.2-cp38-cp38-win_amd64.whl", hash = "sha256:2e9f0b7c5914367b0916c3c104a024bb68f269a486b9d04a2e8ac6f6597b7803"},
+    {file = "PyYAML-5.2.tar.gz", hash = "sha256:c0ee8eca2c582d29c3c2ec6e2c4f703d1b7f1fb10bc72317355a746057e7346c"},
 ]
 regex = [
     {file = "regex-2019.11.1-cp27-none-win32.whl", hash = "sha256:604dc563a02a74d70ae1f55208ddc9bfb6d9f470f6d1a5054c4bd5ae58744ab1"},
@@ -1490,8 +1487,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
 sphinx = [
-    {file = "Sphinx-2.2.1-py3-none-any.whl", hash = "sha256:52286a0b9d7caa31efee301ec4300dbdab23c3b05da1c9024b4e84896fb73d79"},
-    {file = "Sphinx-2.2.1.tar.gz", hash = "sha256:31088dfb95359384b1005619827eaee3056243798c62724fd3fa4b84ee4d71bd"},
+    {file = "Sphinx-2.2.2-py3-none-any.whl", hash = "sha256:3b16e48e791a322d584489ab28d8800652123d1fbfdd173e2965a31d40bf22d7"},
+    {file = "Sphinx-2.2.2.tar.gz", hash = "sha256:559c1a8ed1365a982f77650720b41114414139a635692a23c2990824d0a84cf2"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.1.tar.gz", hash = "sha256:edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897"},
@@ -1569,24 +1566,30 @@ venusian = [
     {file = "venusian-1.2.0.tar.gz", hash = "sha256:64ec8285b80b110d0ae5db4280e90e31848a59db98db1aba4d7d46f48ce91e3e"},
 ]
 virtualenv = [
-    {file = "virtualenv-16.7.7-py2.py3-none-any.whl", hash = "sha256:11cb4608930d5fd3afb545ecf8db83fa50e1f96fc4fca80c94b07d2c83146589"},
-    {file = "virtualenv-16.7.7.tar.gz", hash = "sha256:d257bb3773e48cac60e475a19b608996c73f4d333b3ba2e4e57d5ac6134e0136"},
+    {file = "virtualenv-16.7.8-py2.py3-none-any.whl", hash = "sha256:b57776b44f91511866594e477dd10e76a6eb44439cdd7f06dcd30ba4c5bd854f"},
+    {file = "virtualenv-16.7.8.tar.gz", hash = "sha256:116655188441670978117d0ebb6451eb6a7526f9ae0796cc0dee6bd7356909b0"},
 ]
 wrapt = [
     {file = "wrapt-1.11.2.tar.gz", hash = "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"},
 ]
 yarl = [
-    {file = "yarl-1.3.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:3e2724eb9af5dc41648e5bb304fcf4891adc33258c6e14e2a7414ea32541e320"},
-    {file = "yarl-1.3.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3890ab952d508523ef4881457c4099056546593fa05e93da84c7250516e632eb"},
-    {file = "yarl-1.3.0-cp35-cp35m-win32.whl", hash = "sha256:7ab825726f2940c16d92aaec7d204cfc34ac26c0040da727cf8ba87255a33829"},
-    {file = "yarl-1.3.0-cp35-cp35m-win_amd64.whl", hash = "sha256:b25de84a8c20540531526dfbb0e2d2b648c13fd5dd126728c496d7c3fea33310"},
-    {file = "yarl-1.3.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:2f3010703295fbe1aec51023740871e64bb9664c789cba5a6bdf404e93f7568f"},
-    {file = "yarl-1.3.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5badb97dd0abf26623a9982cd448ff12cb39b8e4c94032ccdedf22ce01a64842"},
-    {file = "yarl-1.3.0-cp36-cp36m-win32.whl", hash = "sha256:c9bb7c249c4432cd47e75af3864bc02d26c9594f49c82e2a28624417f0ae63b8"},
-    {file = "yarl-1.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:c6e341f5a6562af74ba55205dbd56d248daf1b5748ec48a0200ba227bb9e33f4"},
-    {file = "yarl-1.3.0-cp37-cp37m-win32.whl", hash = "sha256:e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1"},
-    {file = "yarl-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:73f447d11b530d860ca1e6b582f947688286ad16ca42256413083d13f260b7a0"},
-    {file = "yarl-1.3.0.tar.gz", hash = "sha256:024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9"},
+    {file = "yarl-1.4.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:3ce3d4f7c6b69c4e4f0704b32eca8123b9c58ae91af740481aa57d7857b5e41b"},
+    {file = "yarl-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:a4844ebb2be14768f7994f2017f70aca39d658a96c786211be5ddbe1c68794c1"},
+    {file = "yarl-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080"},
+    {file = "yarl-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:c2b509ac3d4b988ae8769901c66345425e361d518aecbe4acbfc2567e416626a"},
+    {file = "yarl-1.4.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:308b98b0c8cd1dfef1a0311dc5e38ae8f9b58349226aa0533f15a16717ad702f"},
+    {file = "yarl-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:944494be42fa630134bf907714d40207e646fd5a94423c90d5b514f7b0713fea"},
+    {file = "yarl-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:5b10eb0e7f044cf0b035112446b26a3a2946bca9d7d7edb5e54a2ad2f6652abb"},
+    {file = "yarl-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a161de7e50224e8e3de6e184707476b5a989037dcb24292b391a3d66ff158e70"},
+    {file = "yarl-1.4.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:26d7c90cb04dee1665282a5d1a998defc1a9e012fdca0f33396f81508f49696d"},
+    {file = "yarl-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0c2ab325d33f1b824734b3ef51d4d54a54e0e7a23d13b86974507602334c2cce"},
+    {file = "yarl-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2"},
+    {file = "yarl-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:2098a4b4b9d75ee352807a95cdf5f10180db903bc5b7270715c6bbe2551f64ce"},
+    {file = "yarl-1.4.2-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c9959d49a77b0e07559e579f38b2f3711c2b8716b8410b320bf9713013215a1b"},
+    {file = "yarl-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:25e66e5e2007c7a39541ca13b559cd8ebc2ad8fe00ea94a2aad28a9b1e44e5ae"},
+    {file = "yarl-1.4.2-cp38-cp38-win32.whl", hash = "sha256:6faa19d3824c21bcbfdfce5171e193c8b4ddafdf0ac3f129ccf0cdfcb083e462"},
+    {file = "yarl-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:0ca2f395591bbd85ddd50a82eb1fde9c1066fafe888c5c7cc1d810cf03fd3cc6"},
+    {file = "yarl-1.4.2.tar.gz", hash = "sha256:58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b"},
 ]
 zipp = [
     {file = "zipp-0.6.0-py2.py3-none-any.whl", hash = "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 aiohttp = "^3.6"
-cached-property = "^1.5"
 fastavro = "^0.22.5"
 faust = "^1.7"
 funcy = "^1.13"
@@ -42,7 +41,7 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 88
-known_third_party = ["aiohttp", "cached_property", "fastavro", "faust", "funcy"]
+known_third_party = ["aiohttp", "click", "fastavro", "faust", "funcy"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "faust_avro"
-version = "0.2.1"
+version = "0.3.0"
 description = "Avro codec and schema registry support for Faust"
 authors = ["Mastery Systems LLC <oss@mastery.net>"]
 readme = "README.md"

--- a/tests/cassettes/test_compatible.yaml
+++ b/tests/cassettes/test_compatible.yaml
@@ -5,39 +5,17 @@ interactions:
       Content-Type:
       - application/vnd.schemaregistry.v1+json
     method: POST
-    uri: http://localhost:8081/subjects/test_compatible/versions
-  response:
-    body:
-      string: '{"id":1}'
-    headers:
-      Content-Length: '8'
-      Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:47 GMT
-      Server: Jetty(9.4.18.v20190429)
-      Vary: Accept-Encoding, User-Agent
-    status:
-      code: 200
-      message: OK
-    url: http://localhost:8081/subjects/test_compatible/versions
-- request:
-    body: null
-    headers:
-      Content-Type:
-      - application/vnd.schemaregistry.v1+json
-    method: POST
     uri: http://localhost:8081/compatibility/subjects/test_compatible/versions/latest
   response:
     body:
-      string: '{"is_compatible":true}'
+      string: '{"error_code":40401,"message":"Subject not found."}'
     headers:
-      Content-Encoding: gzip
-      Content-Length: '42'
+      Content-Length: '51'
       Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:47 GMT
+      Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
-      Vary: Accept-Encoding, User-Agent
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     url: http://localhost:8081/compatibility/subjects/test_compatible/versions/latest
 version: 1

--- a/tests/cassettes/test_incompatible.yaml
+++ b/tests/cassettes/test_incompatible.yaml
@@ -12,7 +12,7 @@ interactions:
     headers:
       Content-Length: '8'
       Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:47 GMT
+      Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
       Vary: Accept-Encoding, User-Agent
     status:
@@ -33,7 +33,7 @@ interactions:
       Content-Encoding: gzip
       Content-Length: '43'
       Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:47 GMT
+      Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
       Vary: Accept-Encoding, User-Agent
     status:

--- a/tests/cassettes/test_register.yaml
+++ b/tests/cassettes/test_register.yaml
@@ -12,7 +12,7 @@ interactions:
     headers:
       Content-Length: '8'
       Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:46 GMT
+      Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
       Vary: Accept-Encoding, User-Agent
     status:
@@ -33,7 +33,7 @@ interactions:
       Content-Encoding: gzip
       Content-Length: '129'
       Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:47 GMT
+      Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
       Vary: Accept-Encoding, User-Agent
     status:
@@ -47,12 +47,12 @@ interactions:
     uri: http://localhost:8081/subjects
   response:
     body:
-      string: '["test_register"]'
+      string: '["test_sync_no_schema","test_register","test_incompatible","test_registered","test_self_compatible"]'
     headers:
       Content-Encoding: gzip
-      Content-Length: '37'
+      Content-Length: '80'
       Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:47 GMT
+      Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
       Vary: Accept-Encoding, User-Agent
     status:
@@ -71,7 +71,7 @@ interactions:
       Content-Encoding: gzip
       Content-Length: '99'
       Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:47 GMT
+      Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
       Vary: Accept-Encoding, User-Agent
     status:
@@ -90,7 +90,7 @@ interactions:
       Content-Encoding: gzip
       Content-Length: '129'
       Content-Type: application/vnd.schemaregistry.v1+json
-      Date: Tue, 05 Nov 2019 16:05:47 GMT
+      Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
       Vary: Accept-Encoding, User-Agent
     status:

--- a/tests/cassettes/test_self_compatible.yaml
+++ b/tests/cassettes/test_self_compatible.yaml
@@ -5,7 +5,7 @@ interactions:
       Content-Type:
       - application/vnd.schemaregistry.v1+json
     method: POST
-    uri: http://localhost:8081/subjects/test_registered/versions
+    uri: http://localhost:8081/subjects/test_self_compatible/versions
   response:
     body:
       string: '{"id":1}'
@@ -18,20 +18,20 @@ interactions:
     status:
       code: 200
       message: OK
-    url: http://localhost:8081/subjects/test_registered/versions
+    url: http://localhost:8081/subjects/test_self_compatible/versions
 - request:
     body: null
     headers:
       Content-Type:
       - application/vnd.schemaregistry.v1+json
     method: POST
-    uri: http://localhost:8081/subjects/test_registered
+    uri: http://localhost:8081/compatibility/subjects/test_self_compatible/versions/latest
   response:
     body:
-      string: '{"subject":"test_registered","version":1,"id":1,"schema":"{\"type\":\"record\",\"name\":\"UnitTest\",\"fields\":[{\"name\":\"field\",\"type\":\"string\"}]}"}'
+      string: '{"is_compatible":true}'
     headers:
       Content-Encoding: gzip
-      Content-Length: '130'
+      Content-Length: '42'
       Content-Type: application/vnd.schemaregistry.v1+json
       Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
@@ -39,5 +39,5 @@ interactions:
     status:
       code: 200
       message: OK
-    url: http://localhost:8081/subjects/test_registered
+    url: http://localhost:8081/compatibility/subjects/test_self_compatible/versions/latest
 version: 1

--- a/tests/cassettes/test_sync_no_schema.yaml
+++ b/tests/cassettes/test_sync_no_schema.yaml
@@ -5,7 +5,7 @@ interactions:
       Content-Type:
       - application/vnd.schemaregistry.v1+json
     method: POST
-    uri: http://localhost:8081/subjects/test_registered/versions
+    uri: http://localhost:8081/subjects/test_sync_no_schema/versions
   response:
     body:
       string: '{"id":1}'
@@ -18,26 +18,24 @@ interactions:
     status:
       code: 200
       message: OK
-    url: http://localhost:8081/subjects/test_registered/versions
+    url: http://localhost:8081/subjects/test_sync_no_schema/versions
 - request:
     body: null
     headers:
       Content-Type:
       - application/vnd.schemaregistry.v1+json
     method: POST
-    uri: http://localhost:8081/subjects/test_registered
+    uri: http://localhost:8081/subjects/test_sync_no_schema
   response:
     body:
-      string: '{"subject":"test_registered","version":1,"id":1,"schema":"{\"type\":\"record\",\"name\":\"UnitTest\",\"fields\":[{\"name\":\"field\",\"type\":\"string\"}]}"}'
+      string: '{"error_code":40403,"message":"Schema not found"}'
     headers:
-      Content-Encoding: gzip
-      Content-Length: '130'
+      Content-Length: '49'
       Content-Type: application/vnd.schemaregistry.v1+json
       Date: Sat, 30 Nov 2019 00:46:45 GMT
       Server: Jetty(9.4.18.v20190429)
-      Vary: Accept-Encoding, User-Agent
     status:
-      code: 200
-      message: OK
-    url: http://localhost:8081/subjects/test_registered
+      code: 404
+      message: Not Found
+    url: http://localhost:8081/subjects/test_sync_no_schema
 version: 1

--- a/tests/cassettes/test_sync_no_subject.yaml
+++ b/tests/cassettes/test_sync_no_subject.yaml
@@ -5,7 +5,7 @@ interactions:
       Content-Type:
       - application/vnd.schemaregistry.v1+json
     method: POST
-    uri: http://localhost:8081/subjects/test_unregistered
+    uri: http://localhost:8081/subjects/test_sync_no_subject
   response:
     body:
       string: '{"error_code":40401,"message":"Subject not found."}'
@@ -17,5 +17,5 @@ interactions:
     status:
       code: 404
       message: Not Found
-    url: http://localhost:8081/subjects/test_unregistered
+    url: http://localhost:8081/subjects/test_sync_no_subject
 version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import pytest
-from faust_avro.serializers import Registry
 
 
 @pytest.fixture
 def registry():
+    from faust_avro.registry import Registry
+
     return Registry()
 
 


### PR DESCRIPTION
This PR adds fetching of schemas for which we have a `faust_avro.Record` but we got a new schema_id that we don't recognize. It includes fastavro reader/writer schema translation, so that we should still be able to generate `faust_avro.Record` instances at the cost of dropping some of the writer schema's data.

In order to do this, I had to do a pretty big refactoring of how we're handling that. I decided to use contextvars to pass state along rather than modifying the dozen-function call chain between where I can intercept the app/topic and the codec that needs the app/topic to be able to reach out to the schema registry and fetch stuff.

As part of this change I removed the "fetch all schema ids at boot service" -- those now happen on the fly as needed.