### PR TITLE
Add custom types for lower precision data (int32)

### DIFF
--- a/faust_avro/__init__.py
+++ b/faust_avro/__init__.py
@@ -6,8 +6,13 @@ from faust_avro.exceptions import (
     UnknownTypeError,
 )
 from faust_avro.record import Record
+from faust_avro.types import datetime_millis, float32, int32, time_millis
 
 __all__ = [
+    "int32",
+    "float32",
+    "time_millis",
+    "datetime_millis",
     "App",
     "CodecException",
     "Record",

--- a/faust_avro/schema.py
+++ b/faust_avro/schema.py
@@ -11,6 +11,8 @@ from enum import Enum
 from importlib import import_module
 from typing import Any, Iterable, List, Optional, Set
 
+from faust_avro.types import float32, int32
+
 __all__ = [
     # Types
     "AvroSchemaT",
@@ -105,9 +107,9 @@ class Primitive(Schema):
 
 NULL = Primitive("null", type(None))
 BOOL = Primitive("boolean", bool)
-INT = Primitive("int", int)
+INT = Primitive("int", int32)
 LONG = Primitive("long", int)
-FLOAT = Primitive("float", float)
+FLOAT = Primitive("float", float32)
 DOUBLE = Primitive("double", float)
 BYTES = Primitive("bytes", bytes)
 STRING = Primitive("string", str)

--- a/faust_avro/types.py
+++ b/faust_avro/types.py
@@ -1,0 +1,29 @@
+from datetime import datetime, time
+
+
+class int32(int):
+    """An integer subclass which can be used as a type in python to force
+    an avro int type instead of an avro long."""
+
+    pass
+
+
+class float32(float):
+    """A float subclass which can be used as a type in python to force
+    an avro float type instead of an avro double."""
+
+    pass
+
+
+class time_millis(time):
+    """A time subclass which can be used as a type in python to force
+    an avro logical type of time-millis."""
+
+    pass
+
+
+class datetime_millis(datetime):
+    """A datetime subclass which can be used as a type in python to force
+    an avro logical type of timestamp-millis."""
+
+    pass

--- a/tests/parsers/test_faust.py
+++ b/tests/parsers/test_faust.py
@@ -12,6 +12,7 @@ from faust_avro.schema import (
     BOOL,
     BYTES,
     DOUBLE,
+    FLOAT,
     INT,
     LONG,
     NULL,
@@ -24,6 +25,7 @@ from faust_avro.schema import (
     AvroUnion,
     LogicalType,
 )
+from faust_avro.types import datetime_millis, float32, int32, time_millis
 
 
 class Colors(Enum):
@@ -41,8 +43,10 @@ def test_faust(registry):
 
         # Primitive types
         boolean: bool
-        integer: int
-        floating_pt: float
+        integer: int32
+        longint: int
+        floating_pt: float32
+        double: float
         byte_string: bytes
         text_string: str
         # Complex types
@@ -53,7 +57,9 @@ def test_faust(registry):
         # Logical Types
         calendar_date: date
         daily_time: time
+        daily_time_millis: time_millis
         timestamp: datetime
+        timestamp_millis: datetime_millis
         uuid: UUID
         # Pythonic types
         optional: Optional[str]  # Faust auto-defaults this to None.
@@ -81,8 +87,10 @@ def test_faust(registry):
         fields=[
             # Primitives
             AvroField(name="boolean", type=BOOL),
-            AvroField(name="integer", type=LONG),
-            AvroField(name="floating_pt", type=DOUBLE),
+            AvroField(name="integer", type=INT),
+            AvroField(name="longint", type=LONG),
+            AvroField(name="floating_pt", type=FLOAT),
+            AvroField(name="double", type=DOUBLE),
             AvroField(name="byte_string", type=BYTES),
             AvroField(name="text_string", type=STRING),
             # Complex
@@ -107,8 +115,16 @@ def test_faust(registry):
                 type=LogicalType(logical_type="time-micros", schema=LONG),
             ),
             AvroField(
+                name="daily_time_millis",
+                type=LogicalType(logical_type="time-millis", schema=INT),
+            ),
+            AvroField(
                 name="timestamp",
                 type=LogicalType(logical_type="timestamp-micros", schema=LONG),
+            ),
+            AvroField(
+                name="timestamp_millis",
+                type=LogicalType(logical_type="timestamp-millis", schema=LONG),
             ),
             AvroField(
                 name="uuid", type=LogicalType(logical_type="uuid", schema=STRING)


### PR DESCRIPTION
This PR adds custom types to use reduced-precision `int`, `float`, `time`, and `datetime` avro encodings.

Notes:
* `int32` values have no check for too-large values being encoded. This is up to the user to enforce. Faust's `NumberField`'s min and max value limits can help here.
* `float32` values will retain python's `double` representation internally, leading to loss of precision when being encoded.

TODO:
* [ ] better docs